### PR TITLE
Add navigation pages for announcements and attendance

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,8 @@ This project provides a simple web interface for Discord server administrators t
 
 - **Discord OAuth2 Login** using `passport-discord`.
 - **Check-in/Check-out Buttons** once logged in.
-- **Announcements Sidebar** with mobile-friendly toggle.
+- **Sidebar Navigation** to Announcements, Check-in/out and Admin Status with mobile-friendly toggle.
+- **Admin Status Page** shows currently checked-in administrators.
 - **Responsive Design** prioritizing mobile devices.
 
 ## Setup
@@ -25,4 +26,4 @@ This project provides a simple web interface for Discord server administrators t
    ```
 4. Open `http://localhost:3000` in your browser.
 
-Announcements can be edited directly in `views/index.ejs`.
+Announcements can be edited directly in `views/announcements.ejs`.

--- a/server.js
+++ b/server.js
@@ -46,7 +46,19 @@ function ensureAuthenticated(req, res, next) {
 }
 
 app.get('/', (req, res) => {
-    res.render('index', { user: req.user, checkins });
+    res.redirect('/announcements');
+});
+
+app.get('/announcements', (req, res) => {
+    res.render('announcements', { user: req.user });
+});
+
+app.get('/attendance', (req, res) => {
+    res.render('attendance', { user: req.user, checkins });
+});
+
+app.get('/status', (req, res) => {
+    res.render('status', { user: req.user, checkins });
 });
 
 app.get('/login', passport.authenticate('discord'));
@@ -62,13 +74,21 @@ app.get('/logout', (req, res) => {
 });
 
 app.post('/checkin', ensureAuthenticated, (req, res) => {
-    checkins[req.user.id] = { status: 'in', time: new Date() };
-    res.redirect('/');
+    checkins[req.user.id] = {
+        status: 'in',
+        time: new Date(),
+        username: req.user.username
+    };
+    res.redirect('/attendance');
 });
 
 app.post('/checkout', ensureAuthenticated, (req, res) => {
-    checkins[req.user.id] = { status: 'out', time: new Date() };
-    res.redirect('/');
+    checkins[req.user.id] = {
+        status: 'out',
+        time: new Date(),
+        username: req.user.username
+    };
+    res.redirect('/attendance');
 });
 
 app.listen(PORT, () => {

--- a/views/announcements.ejs
+++ b/views/announcements.ejs
@@ -1,0 +1,47 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>공지사항</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
+    <link rel="stylesheet" href="/css/style.css">
+</head>
+<body>
+<div class="container-fluid">
+    <div class="row">
+        <nav id="sidebar" class="col-12 col-md-3 col-lg-2 d-md-block bg-light sidebar">
+            <div class="position-sticky p-3">
+                <ul class="nav flex-column">
+                    <li class="nav-item"><a class="nav-link" href="/announcements">공지사항</a></li>
+                    <li class="nav-item"><a class="nav-link" href="/attendance">출/퇴근</a></li>
+                    <li class="nav-item"><a class="nav-link" href="/status">관리자 활동현황</a></li>
+                </ul>
+            </div>
+        </nav>
+        <main class="col-md-9 ms-sm-auto col-lg-10 px-md-4">
+            <div class="d-flex justify-content-between flex-wrap flex-md-nowrap align-items-center pt-3 pb-2 mb-3 border-bottom">
+                <div class="d-flex align-items-center">
+                    <button class="btn btn-outline-secondary d-md-none me-2" id="sidebarToggle">☰</button>
+                    <h1 class="h2 m-0">공지사항</h1>
+                </div>
+                <% if (user) { %>
+                    <div>
+                        <span><%= user.username %></span>
+                        <a href="/logout" class="btn btn-sm btn-outline-danger">로그아웃</a>
+                    </div>
+                <% } else { %>
+                    <a href="/login" class="btn btn-primary">Discord 로그인</a>
+                <% } %>
+            </div>
+            <ul id="announcements" class="list-unstyled">
+                <li>환영합니다!</li>
+                <li>관리자는 출근/퇴근을 기록해주세요.</li>
+            </ul>
+        </main>
+    </div>
+</div>
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
+<script src="/js/main.js"></script>
+</body>
+</html>

--- a/views/attendance.ejs
+++ b/views/attendance.ejs
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Discord Admin Check-in</title>
+    <title>출/퇴근</title>
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
     <link rel="stylesheet" href="/css/style.css">
 </head>
@@ -12,10 +12,10 @@
     <div class="row">
         <nav id="sidebar" class="col-12 col-md-3 col-lg-2 d-md-block bg-light sidebar">
             <div class="position-sticky p-3">
-                <h5>공지사항</h5>
-                <ul class="nav flex-column" id="announcements">
-                    <li class="nav-item">환영합니다!</li>
-                    <li class="nav-item">관리자는 출근/퇴근을 기록해주세요.</li>
+                <ul class="nav flex-column">
+                    <li class="nav-item"><a class="nav-link" href="/announcements">공지사항</a></li>
+                    <li class="nav-item"><a class="nav-link" href="/attendance">출/퇴근</a></li>
+                    <li class="nav-item"><a class="nav-link" href="/status">관리자 활동현황</a></li>
                 </ul>
             </div>
         </nav>
@@ -23,7 +23,7 @@
             <div class="d-flex justify-content-between flex-wrap flex-md-nowrap align-items-center pt-3 pb-2 mb-3 border-bottom">
                 <div class="d-flex align-items-center">
                     <button class="btn btn-outline-secondary d-md-none me-2" id="sidebarToggle">☰</button>
-                    <h1 class="h2 m-0">관리자 출근 관리</h1>
+                    <h1 class="h2 m-0">출/퇴근</h1>
                 </div>
                 <% if (user) { %>
                     <div>
@@ -45,7 +45,7 @@
             <h4>출근 현황</h4>
             <ul>
                 <% Object.keys(checkins).forEach(function(id) { %>
-                    <li><%= id %> - <%= checkins[id].status %> (<%= checkins[id].time.toLocaleString() %>)</li>
+                    <li><%= checkins[id].username || id %> - <%= checkins[id].status %> (<%= checkins[id].time.toLocaleString() %>)</li>
                 <% }) %>
             </ul>
             <% } %>

--- a/views/status.ejs
+++ b/views/status.ejs
@@ -1,0 +1,51 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>관리자 활동현황</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
+    <link rel="stylesheet" href="/css/style.css">
+</head>
+<body>
+<div class="container-fluid">
+    <div class="row">
+        <nav id="sidebar" class="col-12 col-md-3 col-lg-2 d-md-block bg-light sidebar">
+            <div class="position-sticky p-3">
+                <ul class="nav flex-column">
+                    <li class="nav-item"><a class="nav-link" href="/announcements">공지사항</a></li>
+                    <li class="nav-item"><a class="nav-link" href="/attendance">출/퇴근</a></li>
+                    <li class="nav-item"><a class="nav-link" href="/status">관리자 활동현황</a></li>
+                </ul>
+            </div>
+        </nav>
+        <main class="col-md-9 ms-sm-auto col-lg-10 px-md-4">
+            <div class="d-flex justify-content-between flex-wrap flex-md-nowrap align-items-center pt-3 pb-2 mb-3 border-bottom">
+                <div class="d-flex align-items-center">
+                    <button class="btn btn-outline-secondary d-md-none me-2" id="sidebarToggle">☰</button>
+                    <h1 class="h2 m-0">관리자 활동현황</h1>
+                </div>
+                <% if (user) { %>
+                    <div>
+                        <span><%= user.username %></span>
+                        <a href="/logout" class="btn btn-sm btn-outline-danger">로그아웃</a>
+                    </div>
+                <% } else { %>
+                    <a href="/login" class="btn btn-primary">Discord 로그인</a>
+                <% } %>
+            </div>
+            <h4>출근중인 관리자</h4>
+            <ul>
+                <% Object.keys(checkins).forEach(function(id) { %>
+                    <% if (checkins[id].status === 'in') { %>
+                        <li><%= checkins[id].username || id %> (<%= checkins[id].time.toLocaleString() %>)</li>
+                    <% } %>
+                <% }) %>
+            </ul>
+        </main>
+    </div>
+</div>
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
+<script src="/js/main.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add sidebar links for 공지사항, 출/퇴근, 관리자 활동현황
- show announcements on the main page and add pages for attendance and status
- store usernames with check-in records
- update README

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_687394a2620c832b9b27c51c75682675