### PR TITLE
Add role table and permission-based login

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This project provides a simple web interface for Discord server administrators t
 - **Check-in/Check-out Buttons** once logged in.
 - **Sidebar Navigation** to Announcements, Check-in/out and Admin Status with mobile-friendly toggle.
 - **Admin Status Page** shows currently checked-in administrators.
-- **Discord Bot** records member roles in a SQLite database to verify admin access.
+- **Discord Bot** stores guild role names and permission flags in SQLite and uses them to verify admin access.
 - **Responsive Design** prioritizing mobile devices.
 
 ## Setup

--- a/database.js
+++ b/database.js
@@ -8,6 +8,11 @@ db.serialize(() => {
     roles TEXT,
     isAdmin INTEGER
   )`);
+  db.run(`CREATE TABLE IF NOT EXISTS roles (
+    id TEXT PRIMARY KEY,
+    name TEXT,
+    permissions INTEGER
+  )`);
 });
 
 module.exports = db;


### PR DESCRIPTION
## Summary
- store guild role names and permission bitfields in SQLite
- populate the roles table at startup and keep it updated on role events
- compute admin access during login using stored role permissions
- document role permission storage in README

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68739fc3a6a4832b8ed55d48ddcaa547