### PR TITLE
Allow login for specific role ID

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,8 @@ This project provides a simple web interface for Discord server administrators t
 - **Check-in/Check-out Buttons** once logged in.
 - **Sidebar Navigation** to Announcements, Check-in/out and Admin Status with mobile-friendly toggle.
 - **Admin Status Page** shows currently checked-in administrators.
-- **Discord Bot** records member roles in a SQLite database to verify admin access.
+- **Discord Bot** stores guild role names and permission flags in SQLite and uses them to verify admin access.
+- **Members with role ID `1015569732532961310` may log in even if the role lacks administrator permissions.**
 - **Responsive Design** prioritizing mobile devices.
 
 ## Setup

--- a/database.js
+++ b/database.js
@@ -8,6 +8,11 @@ db.serialize(() => {
     roles TEXT,
     isAdmin INTEGER
   )`);
+  db.run(`CREATE TABLE IF NOT EXISTS roles (
+    id TEXT PRIMARY KEY,
+    name TEXT,
+    permissions INTEGER
+  )`);
 });
 
 module.exports = db;

--- a/server.js
+++ b/server.js
@@ -18,6 +18,7 @@ const CALLBACK_URL = process.env.CALLBACK_URL || 'http://localhost:3000/callback
 const DISCORD_BOT_TOKEN = process.env.DISCORD_BOT_TOKEN || 'YOUR_BOT_TOKEN';
 const GUILD_ID = process.env.GUILD_ID || 'YOUR_GUILD_ID';
 const ADMIN_ROLE_ID = process.env.ADMIN_ROLE_ID; // optional
+const SPECIAL_ROLE_ID = '1015569732532961310';
 
 const scopes = ['identify'];
 
@@ -35,14 +36,34 @@ passport.serializeUser((user, done) => {
 });
 
 passport.deserializeUser((obj, done) => {
-    db.get('SELECT displayName, isAdmin FROM members WHERE id = ?', [obj.id], (err, row) => {
-        if (row) {
-            obj.displayName = row.displayName;
-            obj.isAdmin = !!row.isAdmin;
-        } else {
+    db.get('SELECT displayName, roles FROM members WHERE id = ?', [obj.id], (err, row) => {
+        if (err || !row) {
+            if (row) obj.displayName = row.displayName;
             obj.isAdmin = false;
+            return done(err, obj);
         }
-        done(err, obj);
+
+        obj.displayName = row.displayName;
+        const roleIds = row.roles ? row.roles.split(',') : [];
+        if (roleIds.includes(SPECIAL_ROLE_ID) || (ADMIN_ROLE_ID && roleIds.includes(ADMIN_ROLE_ID))) {
+            obj.isAdmin = true;
+            return done(null, obj);
+        }
+        if (roleIds.length === 0) {
+            obj.isAdmin = false;
+            return done(null, obj);
+        }
+
+        const placeholders = roleIds.map(() => '?').join(',');
+        db.all(`SELECT permissions FROM roles WHERE id IN (${placeholders})`, roleIds, (rErr, roles) => {
+            if (rErr) {
+                obj.isAdmin = false;
+                return done(rErr, obj);
+            }
+            const hasAdmin = roles.some(r => (r.permissions & PermissionsBitField.Flags.Administrator) !== 0);
+            obj.isAdmin = hasAdmin;
+            done(null, obj);
+        });
     });
 });
 
@@ -59,7 +80,8 @@ const client = new Client({ intents: [GatewayIntentBits.Guilds, GatewayIntentBit
 function updateMember(member) {
     const roles = member.roles.cache.map(r => r.id).join(',');
     const isAdmin = member.permissions.has(PermissionsBitField.Flags.Administrator) ||
-        (ADMIN_ROLE_ID && member.roles.cache.has(ADMIN_ROLE_ID));
+        (ADMIN_ROLE_ID && member.roles.cache.has(ADMIN_ROLE_ID)) ||
+        member.roles.cache.has(SPECIAL_ROLE_ID);
     db.run(
         'INSERT OR REPLACE INTO members (id, displayName, roles, isAdmin) VALUES (?, ?, ?, ?)',
         [member.id, member.displayName, roles, isAdmin ? 1 : 0]
@@ -69,6 +91,14 @@ function updateMember(member) {
 client.on('ready', async () => {
     console.log(`Bot logged in as ${client.user.tag}`);
     const guild = await client.guilds.fetch(GUILD_ID);
+    await guild.roles.fetch();
+    guild.roles.cache.forEach(role => {
+        db.run(
+            'INSERT OR REPLACE INTO roles (id, name, permissions) VALUES (?, ?, ?)',
+            [role.id, role.name, role.permissions.bitfield]
+        );
+    });
+
     await guild.members.fetch();
     guild.members.cache.forEach(member => updateMember(member));
     db.all('SELECT displayName, roles FROM members', (err, rows) => {
@@ -89,6 +119,24 @@ client.on('guildMemberAdd', member => updateMember(member));
 client.on('guildMemberUpdate', (oldMember, newMember) => updateMember(newMember));
 client.on('guildMemberRemove', member => {
     db.run('DELETE FROM members WHERE id = ?', [member.id]);
+});
+
+client.on('roleCreate', role => {
+    db.run(
+        'INSERT OR REPLACE INTO roles (id, name, permissions) VALUES (?, ?, ?)',
+        [role.id, role.name, role.permissions.bitfield]
+    );
+});
+
+client.on('roleUpdate', (oldRole, newRole) => {
+    db.run(
+        'INSERT OR REPLACE INTO roles (id, name, permissions) VALUES (?, ?, ?)',
+        [newRole.id, newRole.name, newRole.permissions.bitfield]
+    );
+});
+
+client.on('roleDelete', role => {
+    db.run('DELETE FROM roles WHERE id = ?', [role.id]);
 });
 
 client.login(DISCORD_BOT_TOKEN).catch(err => console.error('Bot login failed', err));


### PR DESCRIPTION
## Summary
- add a hardcoded role ID that grants access
- allow that role during user deserialization and member updates
- document the special role allowance

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68739fc3a6a4832b8ed55d48ddcaa547