### PR TITLE
Add Docker support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
 node_modules/
 .tmp/
 *.log
-data.db
+data/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,7 @@
+FROM node:20-alpine
+WORKDIR /usr/src/app
+COPY package*.json ./
+RUN npm install --production
+COPY . .
+EXPOSE 3000
+CMD ["npm", "start"]

--- a/README.md
+++ b/README.md
@@ -31,3 +31,20 @@ This project provides a simple web interface for Discord server administrators t
 4. Open `http://localhost:3000` in your browser.
 
 Announcements can be edited directly in `views/announcements.ejs`.
+
+## Docker Compose
+
+You can also run the project using Docker. Create a `.env` file with your Discord credentials and start the stack with Docker Compose 3.8:
+
+```bash
+DISCORD_CLIENT_ID=YOUR_CLIENT_ID
+DISCORD_CLIENT_SECRET=YOUR_CLIENT_SECRET
+DISCORD_BOT_TOKEN=YOUR_BOT_TOKEN
+GUILD_ID=YOUR_GUILD_ID
+ADMIN_ROLE_ID=ROLE_ID_WITH_ADMIN  # optional
+CALLBACK_URL=http://localhost:3000/callback
+
+docker compose up -d
+```
+
+The web interface will be available on `http://localhost:3000`.

--- a/database.js
+++ b/database.js
@@ -1,5 +1,14 @@
 const sqlite3 = require('sqlite3').verbose();
-const db = new sqlite3.Database('./data.db');
+const fs = require('fs');
+const path = require('path');
+
+const dataDir = path.join(__dirname, 'data');
+if (!fs.existsSync(dataDir)) {
+  fs.mkdirSync(dataDir);
+}
+
+const dbPath = path.join(dataDir, 'data.db');
+const db = new sqlite3.Database(dbPath);
 
 db.serialize(() => {
   db.run(`CREATE TABLE IF NOT EXISTS members (

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,12 @@
+version: '3.8'
+services:
+  app:
+    build: .
+    ports:
+      - "3000:3000"
+    env_file:
+      - .env
+    volumes:
+      - data:/usr/src/app/data
+volumes:
+  data:

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "",
   "main": "index.js",
   "scripts": {
+    "start": "node server.js",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "keywords": [],


### PR DESCRIPTION
## Summary
- run database in a `data` folder
- ignore the new data directory
- provide a Dockerfile
- provide a docker-compose.yml for Compose v3.8
- add a start script
- document running with Docker Compose

## Testing
- `npm install`
- `node server.js` *(fails: ENETUNREACH while logging into Discord, server still started)*

------
https://chatgpt.com/codex/tasks/task_e_6873adbfcc28832b812b67ca5c311736