### PR TITLE
Show absent admins on status page

### DIFF
--- a/public/css/style.css
+++ b/public/css/style.css
@@ -32,6 +32,18 @@ body {
     transform: translateY(-2px);
 }
 
+.status-card {
+    transition: transform 0.2s;
+}
+
+.status-card:hover {
+    transform: translateY(-2px);
+}
+
+.inactive-card {
+    background-color: #f8f9fa;
+}
+
 @media (min-width: 768px) {
     #sidebar {
         min-height: 100vh;

--- a/views/status.ejs
+++ b/views/status.ejs
@@ -41,17 +41,40 @@
                 <% } %>
             </div>
             <h4>출근중인 관리자</h4>
-            <div class="row">
+            <div class="row" id="active-admins">
                 <% if (activeAdmins.length === 0) { %>
                     <div class="col-12">출근중인 관리자가 없습니다.</div>
                 <% } else { %>
                     <% activeAdmins.forEach(function(a){ %>
                     <div class="col-6 col-sm-4 col-md-3 col-lg-2 mb-3">
-                        <div class="card h-100 text-center">
+                        <div class="card status-card h-100 text-center">
                             <img src="<%= a.avatar %>" class="card-img-top rounded-circle w-75 mx-auto mt-3" alt="avatar">
                             <div class="card-body p-2">
                                 <h6 class="card-title mb-1"><%= a.displayName %></h6>
                                 <small class="text-muted"><%= a.time.toLocaleString() %></small>
+                            </div>
+                        </div>
+                    </div>
+                    <% }) %>
+                <% } %>
+            </div>
+
+            <h4 class="mt-4">퇴근/미출근 관리자</h4>
+            <div class="row" id="inactive-admins">
+                <% if (inactiveAdmins.length === 0) { %>
+                    <div class="col-12">퇴근 또는 미출근 관리자가 없습니다.</div>
+                <% } else { %>
+                    <% inactiveAdmins.forEach(function(a){ %>
+                    <div class="col-6 col-sm-4 col-md-3 col-lg-2 mb-3">
+                        <div class="card status-card inactive-card h-100 text-center">
+                            <img src="<%= a.avatar %>" class="card-img-top rounded-circle w-75 mx-auto mt-3" alt="avatar">
+                            <div class="card-body p-2">
+                                <h6 class="card-title mb-1"><%= a.displayName %></h6>
+                                <% if (a.time) { %>
+                                <small class="text-muted">마지막 기록: <%= a.time.toLocaleString() %></small>
+                                <% } else { %>
+                                <small class="text-muted">기록 없음</small>
+                                <% } %>
                             </div>
                         </div>
                     </div>


### PR DESCRIPTION
## Summary
- show inactive admins in `/status` route
- style active/inactive cards
- update status page layout

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6877b89b0420832b8a16ca2b3ce43941