### PR TITLE
Add member attendance detail view

### DIFF
--- a/server.js
+++ b/server.js
@@ -461,6 +461,7 @@ app.get('/members/:id', ensureAdmin, async (req, res) => {
     db.get('SELECT date FROM birthdays WHERE userId = ?', [member.id], (err, row) => {
         const birthday = row ? row.date : null;
         const roles = member.roles.cache.filter(r => r.name !== '@everyone').map(r => r.name);
+        const memberCheckins = checkins[member.id] || [];
         res.render('memberDetail', {
             user: req.user,
             member: {
@@ -469,7 +470,8 @@ app.get('/members/:id', ensureAdmin, async (req, res) => {
                 avatar: member.user.displayAvatarURL({ dynamic: true, size: 128 }),
                 birthday,
                 roles
-            }
+            },
+            checkins: memberCheckins
         });
     });
 });

--- a/views/memberDetail.ejs
+++ b/views/memberDetail.ejs
@@ -62,6 +62,18 @@
                     역할 정보가 없습니다.
                 <% } %>
             </div>
+            <div class="mb-3">
+                <strong>출퇴근 기록:</strong>
+                <ul>
+                    <% if (checkins.length === 0) { %>
+                        <li>출퇴근 기록이 없습니다.</li>
+                    <% } else { %>
+                        <% checkins.forEach(function(entry){ %>
+                            <li><%= entry.status %> (<%= entry.time.toLocaleString() %>)</li>
+                        <% }) %>
+                    <% } %>
+                </ul>
+            </div>
         </main>
     </div>
 </div>

--- a/views/status.ejs
+++ b/views/status.ejs
@@ -47,13 +47,15 @@
                 <% } else { %>
                     <% activeAdmins.forEach(function(a){ %>
                     <div class="col-6 col-sm-4 col-md-3 col-lg-2 mb-3">
-                        <div class="card status-card h-100 text-center">
-                            <img src="<%= a.avatar %>" class="card-img-top rounded-circle w-75 mx-auto mt-3" alt="avatar">
-                            <div class="card-body p-2">
-                                <h6 class="card-title mb-1"><%= a.displayName %></h6>
-                                <small class="text-muted"><%= a.time.toLocaleString() %></small>
+                        <a href="/members/<%= a.id %>" class="text-decoration-none text-reset">
+                            <div class="card status-card h-100 text-center">
+                                <img src="<%= a.avatar %>" class="card-img-top rounded-circle w-75 mx-auto mt-3" alt="avatar">
+                                <div class="card-body p-2">
+                                    <h6 class="card-title mb-1"><%= a.displayName %></h6>
+                                    <small class="text-muted"><%= a.time.toLocaleString() %></small>
+                                </div>
                             </div>
-                        </div>
+                        </a>
                     </div>
                     <% }) %>
                 <% } %>
@@ -66,17 +68,19 @@
                 <% } else { %>
                     <% inactiveAdmins.forEach(function(a){ %>
                     <div class="col-6 col-sm-4 col-md-3 col-lg-2 mb-3">
-                        <div class="card status-card inactive-card h-100 text-center">
-                            <img src="<%= a.avatar %>" class="card-img-top rounded-circle w-75 mx-auto mt-3" alt="avatar">
-                            <div class="card-body p-2">
-                                <h6 class="card-title mb-1"><%= a.displayName %></h6>
-                                <% if (a.time) { %>
-                                <small class="text-muted">마지막 기록: <%= a.time.toLocaleString() %></small>
-                                <% } else { %>
-                                <small class="text-muted">기록 없음</small>
-                                <% } %>
+                        <a href="/members/<%= a.id %>" class="text-decoration-none text-reset">
+                            <div class="card status-card inactive-card h-100 text-center">
+                                <img src="<%= a.avatar %>" class="card-img-top rounded-circle w-75 mx-auto mt-3" alt="avatar">
+                                <div class="card-body p-2">
+                                    <h6 class="card-title mb-1"><%= a.displayName %></h6>
+                                    <% if (a.time) { %>
+                                    <small class="text-muted">마지막 기록: <%= a.time.toLocaleString() %></small>
+                                    <% } else { %>
+                                    <small class="text-muted">기록 없음</small>
+                                    <% } %>
+                                </div>
                             </div>
-                        </div>
+                        </a>
                     </div>
                     <% }) %>
                 <% } %>


### PR DESCRIPTION
## Summary
- link member cards on the status page to a detail view
- display check-in/out logs on the member detail page
- expose check-in logs in `/members/:id` route

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6877c1b5fad0832b946c09e333a4b3b0