### PR TITLE
Fix mobile sidebar toggle visibility

### DIFF
--- a/public/css/style.css
+++ b/public/css/style.css
@@ -19,6 +19,12 @@ body {
     background-color: #495057;
     color: #fff;
 }
+#sidebarToggle {
+    background-color: #495057;
+    border-color: #495057;
+    color: #fff;
+}
+
 
 #announcements .card-title {
     font-size: 1.1rem;


### PR DESCRIPTION
## Summary
- style sidebar toggle button so it's not transparent on mobile

## Testing
- `npm test` *(fails: npm not found)*

------
https://chatgpt.com/codex/tasks/task_e_687b591b2438832ba56c5339bc95ac83