### PR TITLE
Allow web admin and special roles full admin access

### DIFF
--- a/server.js
+++ b/server.js
@@ -82,9 +82,9 @@ function loadUser(obj, done) {
         obj.displayName = row.displayName;
         const roleIds = row.roles ? row.roles.split(',') : [];
         const hasLoginRole = roleIds.some(id => loginRoleIds.includes(id));
-        obj.canManageWebAccess = roleIds.includes(WEB_ADMIN_ROLE_ID);
+        obj.canManageWebAccess = roleIds.includes(WEB_ADMIN_ROLE_ID) || roleIds.includes(SPECIAL_ROLE_ID);
 
-        if (roleIds.includes(SPECIAL_ROLE_ID) || (ADMIN_ROLE_ID && roleIds.includes(ADMIN_ROLE_ID))) {
+        if (roleIds.includes(SPECIAL_ROLE_ID) || roleIds.includes(WEB_ADMIN_ROLE_ID) || (ADMIN_ROLE_ID && roleIds.includes(ADMIN_ROLE_ID))) {
             obj.isAdmin = true;
             obj.canLogin = true;
             return done(null, obj);
@@ -132,6 +132,7 @@ function updateMember(member) {
     const isAdmin = member.permissions.has(PermissionsBitField.Flags.Administrator) ||
         (ADMIN_ROLE_ID && member.roles.cache.has(ADMIN_ROLE_ID)) ||
         member.roles.cache.has(SPECIAL_ROLE_ID) ||
+        member.roles.cache.has(WEB_ADMIN_ROLE_ID) ||
         hasLoginRole;
     db.run(
         'INSERT OR REPLACE INTO members (id, displayName, roles, isAdmin) VALUES (?, ?, ?, ?)',


### PR DESCRIPTION
## Summary
- broaden `canManageWebAccess` detection to include the special role
- treat both web admin and special roles as full admins
- store web admin role as admin in member records

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_687b5ae724dc832baf34e4726b642513